### PR TITLE
記録モードと座標コピー機能を実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,11 +210,27 @@
     .leaflet-container {
       background-color: #1a1a1a !important;
     }
+
+    /* Recording mode badge */
+    #rec-badge {
+      position: absolute;
+      top: 50%;
+      right: 16px;
+      transform: translateY(-50%);
+      background-color: #ff0000;
+      color: #ffffff;
+      font-size: 10px;
+      font-weight: bold;
+      padding: 2px 6px;
+      border-radius: 3px;
+      display: none;
+    }
   </style>
 </head>
 
 <body>
   <div class="map-title">
+    <span id="rec-badge">REC</span>
     <div class="map-info">
       <div id="map-title-text">Daemon X Machina: Titanic Scion</div>
       <div class="map-subtitle">Interactive Map</div>

--- a/scripts/add_marker.py
+++ b/scripts/add_marker.py
@@ -8,9 +8,7 @@ Usage: python scripts/add_marker.py {map_id} {category} "{name}" {x} {y}
 
 import argparse
 import json
-import os
 import sys
-import re
 from pathlib import Path
 
 

--- a/src/main.js
+++ b/src/main.js
@@ -74,7 +74,7 @@ class MapManager {
 
     // Recording mode state
     this.isRecordingMode = false;
-    this.RECORDING_MODE_KEY = 'KeyR'; // Shift+R
+    this.RECORDING_MODE_KEY = 'KeyR'; // R key for Shift+R combination
 
     // Initialize map
     this.map = L.map('map', {

--- a/src/main.js
+++ b/src/main.js
@@ -72,6 +72,10 @@ class MapManager {
     this.currentImageOverlay = null;
     this.currentMarkerLayer = null;
 
+    // Recording mode state
+    this.isRecordingMode = false;
+    this.RECORDING_MODE_KEY = 'KeyR'; // Shift+R
+
     // Initialize map
     this.map = L.map('map', {
       crs: L.CRS.Simple,
@@ -92,6 +96,19 @@ class MapManager {
   }
 
   setupEventListeners() {
+    // Recording mode toggle (Shift+R)
+    document.addEventListener('keydown', (e) => {
+      // Skip if input element has focus
+      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable) {
+        return;
+      }
+
+      if (e.code === this.RECORDING_MODE_KEY && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
+        e.preventDefault();
+        this.toggleRecordingMode();
+      }
+    });
+
     // Map navigation link click events
     document.addEventListener('click', (e) => {
       const link = e.target.closest('.map-link');
@@ -112,16 +129,50 @@ class MapManager {
       }
     });
 
-    // Debug: Output clicked position coordinates to console
+    // Map click handler (debug coordinates + recording mode)
     this.map.on('click', e => {
       const x = Math.round(e.latlng.lng); // horizontal
       const y = Math.round(e.latlng.lat); // vertical
-      console.log(`Clicked at: x=${x}, y=${y}`);
+
+      if (this.isRecordingMode) {
+        // Recording mode: Output JSON and copy to clipboard
+        const output = JSON.stringify({ mapId: this.currentMapId, x: x, y: y });
+        console.log(output);
+
+        // Copy to clipboard for use with add_marker.py script
+        // Format: python scripts/add_marker.py {map_id} {category} "{name}" {x} {y}
+        const clipboardText = `${this.currentMapId} <category> "<name>" ${x} ${y}`;
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(clipboardText)
+            .then(() => {
+              console.log(`Copied to clipboard: ${clipboardText}`);
+            })
+            .catch(() => {
+              // Silent fail - no fallback as per requirements
+            });
+        }
+      } else {
+        // Debug mode: Simple coordinate output
+        console.log(`Clicked at: x=${x}, y=${y}`);
+      }
     });
   }
 
   getCurrentCollectionManager() {
     return this.collectionManagers.get(this.currentMapId);
+  }
+
+  toggleRecordingMode() {
+    this.isRecordingMode = !this.isRecordingMode;
+    this.updateRecordingBadge();
+    console.log(`Recording mode: ${this.isRecordingMode ? 'ON' : 'OFF'}`);
+  }
+
+  updateRecordingBadge() {
+    const badge = document.getElementById('rec-badge');
+    if (badge) {
+      badge.style.display = this.isRecordingMode ? 'block' : 'none';
+    }
   }
 
   getMarkerSize() {


### PR DESCRIPTION
fix: #15 AIによる自動PR

## 実装内容

Shift+Rキーで切り替え可能な記録モードと座標コピー機能を実装しました。

### 主な機能
- **記録モード切替**: Shift+Rキーで記録モードをON/OFF
- **RECバッジ表示**: 記録モードON時のみ、マップタイトル右端に赤いRECバッジを表示
- **座標出力**: 記録モード中のマップクリックで以下を実行
  - コンソールにJSON形式で座標情報を出力: `{"mapId":"forest","x":692,"y":548}`
  - クリップボードに`add_marker.py`スクリプト用の引数形式をコピー: `forest <category> "<name>" 692 548`
- **コピー成功ログ**: クリップボードコピー成功時にログ出力

### 技術的特徴
- 入力要素フォーカス時は記録モード切替を無効化
- メモリ上のみでの状態管理（ページ更新でOFFに戻る）
- navigator.clipboard.writeText使用（フォールバックなし）
- マーカーやUI要素のクリックは対象外

### 使用方法
1. Shift+Rを押して記録モードをON
2. マップ上をクリックして座標を取得
3. クリップボードの内容を`scripts/add_marker.py`で使用
   ```bash
   # クリップボードから貼り付けて category と name を編集
   python scripts/add_marker.py forest card "Rare Card" 692 548
   ```

## 実装にあたって参考にした情報や特に注意した点

- Issue #15の仕様に厳密に従い、開発者向け機能として一般ユーザーには露出しない設計
- `scripts/add_marker.py`の引数形式に合わせたクリップボード出力フォーマット
- Leaflet CRS.Simple座標系での正確な座標取得（x=lng, y=lat）
- 座標のMath.roundによる四捨五入処理
- RECバッジのCSS絶対配置による適切な表示位置

## 実装にあたっての質問や懸念点

- HTTPS/localhostでない環境では`navigator.clipboard`が利用できない可能性がありますが、仕様通りフォールバックは実装していません
- プレースホルダー`<category>`と`"<name>"`の形式が適切かご確認ください