### PR TITLE
feat: convert marker collected checkbox to toggle

### DIFF
--- a/public/assets/icons/square-check.svg
+++ b/public/assets/icons/square-check.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="4" width="16" height="16" rx="2" stroke="#000000" stroke-width="2" stroke-linejoin="round" />
+  <path d="M9 12.5L11 14.5L15 10.5" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/public/assets/icons/square.svg
+++ b/public/assets/icons/square.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="4" width="16" height="16" rx="2" stroke="#000000" stroke-width="2" stroke-linejoin="round" />
+</svg>

--- a/src/app-controller.js
+++ b/src/app-controller.js
@@ -144,6 +144,9 @@ export class AppController {
 		console.log(`Marker ${markerId} collection status: ${isNowCollected}`);
 
 		this.mapView.updateMarkerState(markerId, isNowCollected);
+		if (isNowCollected) {
+			this.mapView.showNotification("Done!");
+		}
 		if (this.hideCollected) {
 			void this.searchPanel.refreshResults();
 		}

--- a/src/styles.css
+++ b/src/styles.css
@@ -127,36 +127,100 @@ body {
 	font-style: italic;
 }
 
-.collection-status {
+.marker-actions {
 	margin-top: 12px;
 	padding-top: 12px;
 	border-top: 1px solid var(--border-accent);
-}
-
-.checkbox-label {
 	display: flex;
 	align-items: center;
+	gap: 12px;
+}
+
+.marker-action-button {
+	position: relative;
+	flex: 1 1 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	height: 36px;
+	min-width: 56px;
+	padding: 0;
+	border-radius: 6px;
+	border: 1px solid var(--border-accent);
+	background-color: var(--bg-secondary);
+	color: var(--text-primary);
 	cursor: pointer;
-	font-weight: bold;
-	color: var(--text-primary) !important;
-	font-size: 14px !important;
-	transition: color 0.3s ease;
+	transition:
+		background-color 0.2s ease,
+		border-color 0.2s ease;
 }
 
-.checkbox-label:hover {
-	color: var(--text-bright) !important;
+.marker-action-button:hover,
+.marker-action-button:focus-visible {
+	background-color: var(--bg-tertiary);
+	border-color: var(--accent-green);
 }
 
-.checkbox-label input[type="checkbox"] {
-	margin-right: 8px;
-	width: 16px;
-	height: 16px;
-	cursor: pointer;
-	accent-color: var(--accent-green);
+.marker-action-button:focus-visible {
+	outline: 2px solid var(--accent-green-bright);
+	outline-offset: 2px;
 }
 
-.checkbox-label input[type="checkbox"]:checked {
-	accent-color: var(--accent-green-bright);
+.marker-action-button__icon {
+	width: 18px;
+	height: 18px;
+	background-color: var(--text-primary);
+	transition: background-color 0.2s ease;
+	mask: none;
+	-webkit-mask: none;
+}
+
+.marker-action-button:hover .marker-action-button__icon,
+.marker-action-button:focus-visible .marker-action-button__icon {
+	background-color: var(--text-bright);
+}
+
+.marker-done-toggle .marker-action-button__icon {
+	mask: url("/assets/icons/square.svg") center / contain no-repeat;
+	-webkit-mask: url("/assets/icons/square.svg") center / contain no-repeat;
+}
+
+.marker-done-toggle[aria-pressed="true"] .marker-action-button__icon {
+	mask: url("/assets/icons/square-check.svg") center / contain no-repeat;
+	-webkit-mask:
+		url("/assets/icons/square-check.svg") center / contain no-repeat;
+}
+
+.share-link-button .marker-action-button__icon {
+	mask: url("/assets/icons/link.svg") center / contain no-repeat;
+	-webkit-mask: url("/assets/icons/link.svg") center / contain no-repeat;
+}
+
+.marker-action-button__tooltip {
+	position: absolute;
+	bottom: calc(100% + 6px);
+	right: 0;
+	padding: 4px 8px;
+	background-color: var(--bg-secondary);
+	color: var(--text-primary);
+	border: 1px solid var(--border-accent);
+	border-radius: 4px;
+	white-space: nowrap;
+	font-size: 12px;
+	box-shadow: 0 4px 8px var(--shadow-dark);
+	opacity: 0;
+	transform: translateY(4px);
+	transition:
+		opacity 0.2s ease,
+		transform 0.2s ease;
+	pointer-events: none;
+	z-index: 10;
+}
+
+.marker-action-button:hover .marker-action-button__tooltip,
+.marker-action-button:focus-visible .marker-action-button__tooltip {
+	opacity: 1;
+	transform: translateY(0);
 }
 
 /* Leaflet controls dark theme */

--- a/src/url-state.js
+++ b/src/url-state.js
@@ -11,6 +11,28 @@ function getCurrentUrl() {
 	return new URL(window.location.href);
 }
 
+function applyStateToUrl(url, { mapId, markerId, zoom }) {
+	if (mapId === null) {
+		url.searchParams.delete(MAP_PARAM);
+	} else if (mapId && isValidMapId(mapId)) {
+		url.searchParams.set(MAP_PARAM, mapId);
+	}
+
+	if (markerId === null) {
+		url.searchParams.delete(MARKER_PARAM);
+	} else if (markerId && validateMarkerId(markerId)) {
+		url.searchParams.set(MARKER_PARAM, markerId);
+	}
+
+	if (zoom === null) {
+		url.searchParams.delete(ZOOM_PARAM);
+	} else if (typeof zoom === "number" && Number.isFinite(zoom)) {
+		url.searchParams.set(ZOOM_PARAM, zoom.toString());
+	}
+
+	return url;
+}
+
 function sanitizeZoomParam(value) {
 	const parsed = Number.parseFloat(value);
 	return Number.isFinite(parsed) ? parsed : null;
@@ -48,29 +70,20 @@ export function updateUrlState({ mapId, markerId, zoom }) {
 		return;
 	}
 
-	const url = getCurrentUrl();
-
-	if (mapId === null) {
-		url.searchParams.delete(MAP_PARAM);
-	} else if (mapId && isValidMapId(mapId)) {
-		url.searchParams.set(MAP_PARAM, mapId);
-	}
-
-	if (markerId === null) {
-		url.searchParams.delete(MARKER_PARAM);
-	} else if (markerId && validateMarkerId(markerId)) {
-		url.searchParams.set(MARKER_PARAM, markerId);
-	}
-
-	if (zoom === null) {
-		url.searchParams.delete(ZOOM_PARAM);
-	} else if (typeof zoom === "number" && Number.isFinite(zoom)) {
-		url.searchParams.set(ZOOM_PARAM, zoom.toString());
-	}
+	const url = applyStateToUrl(getCurrentUrl(), { mapId, markerId, zoom });
 
 	const newUrl = `${url.pathname}${url.search}${url.hash}`;
 	const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
 	if (newUrl !== current) {
 		history.replaceState(null, "", newUrl);
 	}
+}
+
+export function createShareUrl({ mapId, markerId, zoom }) {
+	if (typeof window === "undefined") {
+		return "";
+	}
+
+	const url = applyStateToUrl(getCurrentUrl(), { mapId, markerId, zoom });
+	return url.toString();
 }

--- a/tests/hide-collected.spec.js
+++ b/tests/hide-collected.spec.js
@@ -40,11 +40,10 @@ test.describe("hide collected toggle", () => {
 		await expect(popup).toBeVisible();
 		await expect(popup).toContainText("Pierced Heart");
 
-		const collectedCheckbox = popup.getByRole("checkbox", {
-			name: "Collected",
-		});
-		await expect(collectedCheckbox).not.toBeChecked();
-		await collectedCheckbox.check();
+		const doneToggle = popup.locator(".marker-done-toggle");
+		await expect(doneToggle).toHaveAttribute("aria-pressed", "false");
+		await doneToggle.click();
+		await expect(doneToggle).toHaveAttribute("aria-pressed", "true");
 
 		await hideToggle.click();
 		await expect(hideToggle).toHaveAttribute("aria-pressed", "true");

--- a/tests/marker-popup-share.spec.js
+++ b/tests/marker-popup-share.spec.js
@@ -1,0 +1,215 @@
+import { expect, test } from "@playwright/test";
+
+const mapId = "desert";
+const markerId = "desert-054";
+const storageKey = `collect-map:v1:${mapId}`;
+
+async function setupClipboardMock(page) {
+	await page.addInitScript(() => {
+		const calls = [];
+		const existing = window.navigator.clipboard ?? {};
+		const clipboard = {
+			...existing,
+			writeText: (text) => {
+				calls.push(text);
+				return Promise.resolve();
+			},
+		};
+		Object.defineProperty(window.navigator, "clipboard", {
+			configurable: true,
+			value: clipboard,
+		});
+		window.__clipboardCalls = calls;
+	});
+}
+
+async function openPopup(page, options = {}) {
+	await setupClipboardMock(page);
+	await page.goto(`/?map=${mapId}&marker=${markerId}&zoom=1.25`);
+
+	if (Object.hasOwn(options, "initialDone")) {
+		const state = options.initialDone
+			? { [markerId]: true }
+			: { [markerId]: false };
+		await page.evaluate(
+			({ key, value }) => {
+				localStorage.setItem(key, JSON.stringify(value));
+			},
+			{ key: storageKey, value: state },
+		);
+		await page.reload();
+	}
+
+	const popup = page.locator(".leaflet-popup");
+	await expect(popup).toBeVisible();
+	return popup;
+}
+
+async function getMaskImage(locator) {
+	return locator.evaluate((element) => {
+		const styles = window.getComputedStyle(element);
+		return styles.maskImage || styles.webkitMaskImage || "";
+	});
+}
+
+test.describe("marker popup actions", () => {
+	test("popup shows copy link button with tooltip and layout", async ({
+		page,
+	}) => {
+		const popup = await openPopup(page);
+		const button = popup.getByRole("button", { name: "Copy marker link" });
+		await expect(button).toBeVisible();
+
+		const describedBy = await button.getAttribute("aria-describedby");
+		expect(describedBy).toBeTruthy();
+
+		const tooltip = popup.locator(`#${describedBy}`);
+		await expect(tooltip).toHaveAttribute("role", "tooltip");
+		await expect(tooltip).toHaveText("Copy link");
+
+		const parentClass = await button.evaluate(
+			(el) => el.parentElement?.className,
+		);
+		expect(parentClass ?? "").toContain("marker-actions");
+
+		const siblings = button.evaluate((el) => {
+			const parent = el.parentElement;
+			if (!parent) {
+				return [];
+			}
+			return Array.from(parent.children).map((child) => child.className);
+		});
+		const classList = await siblings;
+		expect(classList[0]).toContain("marker-done-toggle");
+	});
+
+	test("done toggle exposes default state", async ({ page }) => {
+		const popup = await openPopup(page, { initialDone: false });
+		const doneButton = popup.getByRole("button", { name: "Mark as done" });
+		await expect(doneButton).toHaveAttribute("aria-pressed", "false");
+
+		const tooltipId = await doneButton.getAttribute("aria-describedby");
+		const tooltip = popup.locator(`#${tooltipId}`);
+		await expect(tooltip).toHaveText("Mark as done");
+
+		const icon = popup.locator(
+			".marker-done-toggle .marker-action-button__icon",
+		);
+		const mask = await getMaskImage(icon);
+		expect(mask).toContain("square.svg");
+	});
+
+	test("done toggle reflects stored true state", async ({ page }) => {
+		const popup = await openPopup(page, { initialDone: true });
+		const doneButton = popup.getByRole("button", { name: "Unmark done" });
+		await expect(doneButton).toHaveAttribute("aria-pressed", "true");
+
+		const tooltipId = await doneButton.getAttribute("aria-describedby");
+		const tooltip = popup.locator(`#${tooltipId}`);
+		await expect(tooltip).toHaveText("Unmark done");
+
+		const icon = popup.locator(
+			".marker-done-toggle .marker-action-button__icon",
+		);
+		const mask = await getMaskImage(icon);
+		expect(mask).toContain("square-check.svg");
+	});
+
+	test("toggle updates state, shows toast once, and persists", async ({
+		page,
+	}) => {
+		const popup = await openPopup(page, { initialDone: false });
+		const doneButton = popup.locator(".marker-done-toggle");
+
+		await expect(doneButton).toHaveAttribute("aria-pressed", "false");
+		await doneButton.click();
+		await expect(doneButton).toHaveAttribute("aria-pressed", "true");
+
+		const toast = page.locator(".notification-toast");
+		await expect(toast).toContainText("Done!");
+		await toast.waitFor({ state: "detached" });
+
+		const tooltipId = await doneButton.getAttribute("aria-describedby");
+		const tooltip = popup.locator(`#${tooltipId}`);
+		await expect(tooltip).toHaveText("Unmark done");
+
+		const icon = popup.locator(
+			".marker-done-toggle .marker-action-button__icon",
+		);
+		const mask = await getMaskImage(icon);
+		expect(mask).toContain("square-check.svg");
+
+		const storedAfterCheck = await page.evaluate(
+			({ key }) => {
+				const raw = localStorage.getItem(key);
+				return raw ? JSON.parse(raw) : null;
+			},
+			{ key: storageKey },
+		);
+		expect(storedAfterCheck?.[markerId]).toBe(true);
+
+		await page.reload();
+		const popupAfterReload = page.locator(".leaflet-popup");
+		await expect(popupAfterReload).toBeVisible();
+		const toggleAfterReload = popupAfterReload.locator(".marker-done-toggle");
+		await expect(toggleAfterReload).toHaveAttribute("aria-pressed", "true");
+
+		await toggleAfterReload.click();
+		await expect(toggleAfterReload).toHaveAttribute("aria-pressed", "false");
+		await expect(page.locator(".notification-toast")).toHaveCount(0, {
+			timeout: 500,
+		});
+
+		const storedAfterUncheck = await page.evaluate(
+			({ key }) => {
+				const raw = localStorage.getItem(key);
+				return raw ? JSON.parse(raw) : null;
+			},
+			{ key: storageKey },
+		);
+		expect(storedAfterUncheck?.[markerId]).toBe(false);
+	});
+
+	test("click copies share url and shows toast", async ({ page }) => {
+		await openPopup(page);
+		const button = page.getByRole("button", { name: "Copy marker link" });
+		await button.click();
+
+		const toast = page.locator(".notification-toast");
+		await expect(toast).toContainText("Link copied!");
+
+		const clipboardCalls = await page.evaluate(
+			() => window.__clipboardCalls ?? [],
+		);
+		expect(clipboardCalls).toHaveLength(1);
+
+		const copiedUrl = clipboardCalls[0];
+		const parsed = new URL(copiedUrl);
+		expect(parsed.searchParams.get("map")).toBe(mapId);
+		expect(parsed.searchParams.get("marker")).toBe(markerId);
+		expect(parsed.searchParams.has("zoom")).toBe(true);
+
+		const currentZoom = await page.evaluate(
+			() => window.__DXM_MAP_VIEW__?.getZoomLevel() ?? null,
+		);
+		if (currentZoom !== null) {
+			const zoomParam = Number.parseFloat(
+				parsed.searchParams.get("zoom") ?? "NaN",
+			);
+			expect(Number.isNaN(zoomParam)).toBe(false);
+			expect(zoomParam).toBeCloseTo(currentZoom, 2);
+		}
+	});
+
+	test("keyboard activation copies share url", async ({ page }) => {
+		await openPopup(page);
+		const button = page.getByRole("button", { name: "Copy marker link" });
+		await button.focus();
+		await page.keyboard.press("Enter");
+
+		const clipboardCalls = await page.evaluate(
+			() => window.__clipboardCalls ?? [],
+		);
+		expect(clipboardCalls).toHaveLength(1);
+	});
+});

--- a/tests/shared-marker-navigation.spec.js
+++ b/tests/shared-marker-navigation.spec.js
@@ -64,10 +64,10 @@ test.describe("shared marker navigation", () => {
 		const popup = page.locator(".leaflet-popup");
 		await expect(popup).toBeVisible();
 
-		const collectedCheckbox = popup.getByRole("checkbox", {
-			name: "Collected",
-		});
-		await collectedCheckbox.check();
+		const doneToggle = popup.locator(".marker-done-toggle");
+		await expect(doneToggle).toHaveAttribute("aria-pressed", "false");
+		await doneToggle.click();
+		await expect(doneToggle).toHaveAttribute("aria-pressed", "true");
 
 		const hideToggle = page.getByTestId("hide-toggle");
 		await hideToggle.click();


### PR DESCRIPTION
## Summary
- replace the marker popup checkbox with an icon toggle that wires into the existing collection callbacks and refreshes the share button layout
- adjust popup styling and add the new square icons so the done toggle visually matches the copy link control
- refresh controller logic and e2e tests to surface the new done button, including persistence checks and toast expectations

## Testing
- pnpm test
- pnpm exec playwright test
- pnpm check

------
https://chatgpt.com/codex/tasks/task_e_68d3960a2164832c8cd3ef1f95e1166b