### PR TITLE
chore: set up TypeScript tooling

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Type check
+        run: pnpm typecheck
+
       - name: Build
         run: pnpm build
 

--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,7 @@
 			"tests/**",
 			".vscode/**",
 			"*.js",
+			"*.ts",
 			"*.json",
 			"*.html",
 			"*.css"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
+		"typecheck": "tsc --noEmit",
 		"preview": "vite preview --base /daemonxmachina-titanicscion-interactive-map/",
 		"lint": "biome lint . --write",
 		"format": "biome format . --write",
@@ -29,10 +30,12 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.2.4",
 		"@playwright/test": "^1.55.0",
+		"@types/node": "^24.5.2",
+		"@vitest/coverage-v8": "^2.1.4",
 		"playwright": "^1.55.0",
+		"typescript": "^5.9.2",
 		"vite": "^5.4.0",
-		"vitest": "^2.1.4",
-		"@vitest/coverage-v8": "^2.1.4"
+		"vitest": "^2.1.4"
 	},
 	"engines": {
 		"node": ">=22.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,18 +21,24 @@ importers:
       '@playwright/test':
         specifier: ^1.55.0
         version: 1.55.0
+      '@types/node':
+        specifier: ^24.5.2
+        version: 24.5.2
       '@vitest/coverage-v8':
         specifier: ^2.1.4
-        version: 2.1.9(vitest@2.1.9)
+        version: 2.1.9(vitest@2.1.9(@types/node@24.5.2))
       playwright:
         specifier: ^1.55.0
         version: 1.55.0
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
       vite:
         specifier: ^5.4.0
-        version: 5.4.20
+        version: 5.4.20(@types/node@24.5.2)
       vitest:
         specifier: ^2.1.4
-        version: 2.1.9
+        version: 2.1.9(@types/node@24.5.2)
 
 packages:
 
@@ -394,6 +400,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node@24.5.2':
+    resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -722,6 +731,14 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.12.0:
+    resolution: {integrity: sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==}
+
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -1027,10 +1044,14 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@24.5.2':
+    dependencies:
+      undici-types: 7.12.0
+
   '@types/trusted-types@2.0.7':
     optional: true
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9)':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@24.5.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -1044,7 +1065,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.9
+      vitest: 2.1.9(@types/node@24.5.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -1055,13 +1076,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.20)':
+  '@vitest/mocker@2.1.9(vite@5.4.20(@types/node@24.5.2))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 5.4.20
+      vite: 5.4.20(@types/node@24.5.2)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -1380,13 +1401,17 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
-  vite-node@2.1.9:
+  typescript@5.9.2: {}
+
+  undici-types@7.12.0: {}
+
+  vite-node@2.1.9(@types/node@24.5.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.20
+      vite: 5.4.20(@types/node@24.5.2)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1398,18 +1423,19 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.20:
+  vite@5.4.20(@types/node@24.5.2):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.52.0
     optionalDependencies:
+      '@types/node': 24.5.2
       fsevents: 2.3.3
 
-  vitest@2.1.9:
+  vitest@2.1.9(@types/node@24.5.2):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.20)
+      '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@24.5.2))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -1425,9 +1451,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.20
-      vite-node: 2.1.9
+      vite: 5.4.20(@types/node@24.5.2)
+      vite-node: 2.1.9(@types/node@24.5.2)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.5.2
     transitivePeerDependencies:
       - less
       - lightningcss

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"lib": ["DOM", "DOM.Iterable", "ES2020"],
+		"moduleResolution": "Bundler",
+		"allowJs": true,
+		"checkJs": false,
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+		"strict": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*", "tests/**/*"],
+	"exclude": ["dist", "node_modules"],
+	"references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"compilerOptions": {
+		"composite": true,
+		"module": "ESNext",
+		"moduleResolution": "Node",
+		"target": "ES2020",
+		"lib": ["ES2020"],
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"types": ["node"]
+	},
+	"include": ["vite.config.ts", "vitest.config.js", "scripts/**/*.js"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,8 @@
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
+
+const projectRoot = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig(({ command }) => {
 	const isBuild = command === "build";
@@ -12,8 +15,8 @@ export default defineConfig(({ command }) => {
 			sourcemap: true,
 			rollupOptions: {
 				input: {
-					main: resolve(__dirname, "index.html"),
-					about: resolve(__dirname, "about.html"),
+					main: resolve(projectRoot, "index.html"),
+					about: resolve(projectRoot, "about.html"),
 				},
 				output: {
 					manualChunks: {


### PR DESCRIPTION
## Summary
- add TypeScript compiler dependencies and expose a pnpm typecheck script
- introduce project and node-specific tsconfig files and convert the Vite config to TypeScript with ESM-safe path resolution
- update Biome configuration and the Pages workflow to include TypeScript sources and run type checks during CI

## Testing
- pnpm typecheck
- pnpm check

------
https://chatgpt.com/codex/tasks/task_e_68d4f619c26c832cb55f2742d0c8fd48