### PR TITLE
feat: add shared type definitions for map modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.2.4",
 		"@playwright/test": "^1.55.0",
+		"@types/geojson": "^7946.0.16",
+		"@types/leaflet": "^1.9.20",
 		"@types/node": "^24.5.2",
 		"@vitest/coverage-v8": "^2.1.4",
 		"playwright": "^1.55.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,12 @@ importers:
       '@playwright/test':
         specifier: ^1.55.0
         version: 1.55.0
+      '@types/geojson':
+        specifier: ^7946.0.16
+        version: 7946.0.16
+      '@types/leaflet':
+        specifier: ^1.9.20
+        version: 1.9.20
       '@types/node':
         specifier: ^24.5.2
         version: 24.5.2
@@ -399,6 +405,12 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/leaflet@1.9.20':
+    resolution: {integrity: sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==}
 
   '@types/node@24.5.2':
     resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
@@ -1043,6 +1055,12 @@ snapshots:
     optional: true
 
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
+
+  '@types/leaflet@1.9.20':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/node@24.5.2':
     dependencies:

--- a/src/collection-store.js
+++ b/src/collection-store.js
@@ -4,14 +4,21 @@ import { getDefaultMapId, isValidMapId } from "./map-definitions.js";
 import { validateMarkerId } from "./validation.js";
 
 export class CollectionManager {
+	/**
+	 * @param {import("./types").MapId} [mapId]
+	 */
 	constructor(mapId = getDefaultMapId()) {
+		/** @type {import("./types").MapId} */
 		this.mapId = this.validateMapId(mapId);
 		this.storageKey = `collect-map:v1:${this.mapId}`;
+		/** @type {import("./types").CollectionState} */
 		this.collectedItems = this.loadFromStorage();
 	}
 
 	/**
 	 * Validate map ID
+	 * @param {unknown} mapId
+	 * @returns {import("./types").MapId}
 	 */
 	validateMapId(mapId) {
 		if (!isValidMapId(mapId)) {
@@ -23,6 +30,9 @@ export class CollectionManager {
 		return mapId;
 	}
 
+	/**
+	 * @returns {import("./types").CollectionState}
+	 */
 	loadFromStorage() {
 		try {
 			const stored = localStorage.getItem(this.storageKey);
@@ -46,6 +56,7 @@ export class CollectionManager {
 			}
 
 			// Properties validation
+			/** @type {import("./types").CollectionState} */
 			const validated = {};
 			for (const [key, value] of Object.entries(parsed)) {
 				// Marker ID validation and value type check
@@ -64,6 +75,9 @@ export class CollectionManager {
 		}
 	}
 
+	/**
+	 * @returns {boolean}
+	 */
 	saveToStorage() {
 		try {
 			// Data size limit (under 5MB)
@@ -96,6 +110,10 @@ export class CollectionManager {
 		}
 	}
 
+	/**
+	 * @param {import("./types").MarkerId} markerId
+	 * @returns {boolean}
+	 */
 	isCollected(markerId) {
 		if (!validateMarkerId(markerId)) {
 			return false;
@@ -103,6 +121,10 @@ export class CollectionManager {
 		return Boolean(this.collectedItems[markerId]);
 	}
 
+	/**
+	 * @param {import("./types").MarkerId} markerId
+	 * @returns {boolean}
+	 */
 	toggleCollection(markerId) {
 		if (!validateMarkerId(markerId)) {
 			console.error(`Invalid marker ID: ${markerId}`);
@@ -121,6 +143,11 @@ export class CollectionManager {
 		return this.collectedItems[markerId];
 	}
 
+	/**
+	 * @param {import("./types").MarkerId} markerId
+	 * @param {boolean} isCollected
+	 * @returns {boolean}
+	 */
 	setCollected(markerId, isCollected) {
 		if (!validateMarkerId(markerId)) {
 			console.error(`Invalid marker ID: ${markerId}`);

--- a/src/map-definitions.js
+++ b/src/map-definitions.js
@@ -3,9 +3,11 @@
 import { getAssetPath } from "./asset-path.js";
 
 // Default configuration constants
+/** @type {import("./types").MapId} */
 export const DEFAULT_MAP_ID = "desert";
 export const LAST_MAP_STORAGE_KEY = "last-selected-map:v1";
 
+/** @type {import("./types").MapDefinitions} */
 export const mapDefinitions = {
 	forest: {
 		name: "Forest Map",
@@ -39,12 +41,19 @@ export const mapDefinitions = {
 /**
  * Get map definition by ID
  */
+/**
+ * @param {import("./types").MapId} mapId
+ * @returns {import("./types").MapDefinition | null}
+ */
 export function getMapDefinition(mapId) {
 	return mapDefinitions[mapId] || null;
 }
 
 /**
  * Get all available map IDs
+ */
+/**
+ * @returns {import("./types").MapId[]}
  */
 export function getAllMapIds() {
 	return Object.keys(mapDefinitions);
@@ -53,6 +62,10 @@ export function getAllMapIds() {
 /**
  * Validate map ID
  */
+/**
+ * @param {unknown} mapId
+ * @returns {mapId is import("./types").MapId}
+ */
 export function isValidMapId(mapId) {
 	return mapId && Object.hasOwn(mapDefinitions, mapId);
 }
@@ -60,12 +73,16 @@ export function isValidMapId(mapId) {
 /**
  * Get default map ID
  */
+/**
+ * @returns {import("./types").MapId}
+ */
 export function getDefaultMapId() {
 	return DEFAULT_MAP_ID;
 }
 
 /**
  * Get last selected map from localStorage, fallback to default
+ * @returns {import("./types").MapId}
  */
 export function getInitialMapId() {
 	try {
@@ -85,6 +102,10 @@ export function getInitialMapId() {
 
 /**
  * Save map selection to localStorage
+ */
+/**
+ * @param {import("./types").MapId} mapId
+ * @returns {boolean}
  */
 export function saveSelectedMap(mapId) {
 	if (!isValidMapId(mapId)) {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,70 @@
+import type { Feature, FeatureCollection, Point } from "geojson";
+
+export type MapId = "forest" | "desert" | "mountains";
+
+export type MarkerCategory =
+	| "music"
+	| "card"
+	| "decal"
+	| "chest"
+	| "enemy"
+	| "boss"
+	| "dungeon"
+	| "log"
+	| "duelist"
+	| "shop";
+
+export interface MarkerProperties {
+	id: string;
+	name: string;
+	category: MarkerCategory;
+	description?: string;
+	notes?: string;
+	[key: string]: unknown;
+}
+
+export type MarkerFeature = Feature<Point, MarkerProperties>;
+
+export type MarkerFeatureCollection = FeatureCollection<
+	Point,
+	MarkerProperties
+>;
+
+export type MarkerId = MarkerProperties["id"];
+
+export type MapBounds = [[number, number], [number, number]];
+
+export interface MapDefinition {
+	name: string;
+	imagePath: string;
+	bounds: MapBounds;
+	markersPath: string;
+}
+
+export type MapDefinitions = Record<MapId, MapDefinition>;
+
+export type CollectionState = Record<MarkerId, boolean>;
+
+export interface CollectionStore {
+	isCollected(markerId: MarkerId): boolean;
+	toggleCollection(markerId: MarkerId): boolean;
+	setCollected(markerId: MarkerId, collected: boolean): boolean;
+}
+
+export interface MarkerFocusOptions {
+	zoom?: number;
+	panOffset?: [number, number];
+	forceVisibility?: boolean;
+}
+
+export interface MarkerShareOptions {
+	markerId: MarkerId;
+	mapId: MapId;
+	zoom?: number;
+}
+
+export interface MapViewCallbacks {
+	onMarkerToggle?: (markerId: MarkerId) => void;
+	onMapSwitch?: (mapId: MapId) => void;
+	onRecordingModeToggle?: (isRecording: boolean) => void;
+}

--- a/src/types/leaflet-extensions.d.ts
+++ b/src/types/leaflet-extensions.d.ts
@@ -1,0 +1,19 @@
+import type * as GeoJSON from "geojson";
+import type {
+	GeoJSON as LeafletGeoJSON,
+	GeoJSONOptions,
+	Marker,
+} from "leaflet";
+import type {
+	MarkerFeature,
+	MarkerFeatureCollection,
+	MarkerProperties,
+} from "./index";
+
+declare module "leaflet" {
+	type DxmMarker = Marker<MarkerProperties>;
+	type DxmMarkerFeature = MarkerFeature;
+	type DxmMarkerCollection = MarkerFeatureCollection;
+	type DxmGeoJsonOptions = GeoJSONOptions<MarkerProperties, GeoJSON.Point>;
+	type DxmGeoJsonLayer = LeafletGeoJSON<MarkerFeatureCollection>;
+}

--- a/src/validation.js
+++ b/src/validation.js
@@ -22,6 +22,8 @@ function containsUnsafeHTML(text) {
 
 /**
  * Validate marker ID format
+ * @param {unknown} markerId
+ * @returns {markerId is import("./types").MarkerId}
  */
 export function validateMarkerId(markerId) {
 	if (typeof markerId !== "string") {
@@ -34,6 +36,8 @@ export function validateMarkerId(markerId) {
 
 /**
  * Validate GeoJSON feature data
+ * @param {unknown} feature
+ * @returns {feature is import("./types").MarkerFeature}
  */
 export function validateGeoJSONFeature(feature) {
 	// Basic structure check

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"target": "ES2020",
 		"module": "ESNext",
-		"lib": ["DOM", "DOM.Iterable", "ES2020"],
+		"lib": ["DOM", "DOM.Iterable", "ES2023"],
 		"moduleResolution": "Bundler",
 		"allowJs": true,
 		"checkJs": false,
@@ -13,7 +13,8 @@
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,
 		"isolatedModules": true,
-		"noEmit": true
+		"noEmit": true,
+		"types": ["node"]
 	},
 	"include": ["src/**/*", "tests/**/*"],
 	"exclude": ["dist", "node_modules"],


### PR DESCRIPTION
## Summary
- add shared map, marker, and collection types in `src/types` plus leaflet helper aliases for upcoming TS migration
- update map loading, validation, and collection modules to consume shared type aliases through JSDoc guards
- configure TypeScript to include Node libs and install GeoJSON/Leaflet typings for editor and CI safety nets

## Testing
- pnpm check
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d501cce86c832c8bd45956a0800511