### PR TITLE
Fix CLI typings and test coverage for TypeScript migration

### DIFF
--- a/scripts/add_marker.d.ts
+++ b/scripts/add_marker.d.ts
@@ -1,0 +1,116 @@
+import type { PathLike } from "node:fs";
+
+export type CategoryId = string;
+
+export interface MarkerProperties extends Record<string, unknown> {
+        id: string;
+        name: string;
+        category: CategoryId;
+        description?: string;
+}
+
+export interface MarkerGeometry {
+        type: "Point";
+        coordinates: [number, number];
+}
+
+export interface MarkerFeature extends FeatureLike {
+        type: "Feature";
+        geometry: MarkerGeometry;
+        properties: MarkerProperties;
+}
+
+export interface FeatureLike {
+        type?: string;
+        geometry?: {
+                type?: string;
+                coordinates?: [number, number] | number[];
+        };
+        properties?: Record<string, unknown>;
+}
+
+export interface FeatureCollectionLike {
+        type: "FeatureCollection";
+        features: FeatureLike[];
+}
+
+export interface MarkerArgumentsBase {
+        dryRun: boolean;
+}
+
+export interface MarkerArguments extends MarkerArgumentsBase {
+        categoriesFlag: false;
+        mapId: string;
+        x: number;
+        y: number;
+        category: CategoryId;
+        name: string;
+        description: string;
+}
+
+export interface CategoryListArguments extends MarkerArgumentsBase {
+        categoriesFlag: true;
+        mapId: undefined;
+        x: undefined;
+        y: undefined;
+        category: undefined;
+        name: undefined;
+        description: "";
+}
+
+export type ParsedArguments = MarkerArguments | CategoryListArguments;
+
+export interface MarkerInput {
+        dryRun?: boolean;
+        mapId?: string;
+        x: unknown;
+        y: unknown;
+        category: unknown;
+        name: unknown;
+        description?: unknown;
+}
+
+export interface ValidatedMarkerInput {
+        dryRun?: boolean;
+        mapId?: string;
+        x: number;
+        y: number;
+        category: string;
+        name: string;
+        description: string;
+}
+
+export const VALID_CATEGORIES: readonly CategoryId[];
+export const DEFAULT_MARKERS_DIR: string;
+export function parseArguments(argv?: string[]): ParsedArguments;
+export function showCategories(categories?: readonly CategoryId[]): void;
+export function getFilePath(mapId: string, markersDir?: string): string;
+export function validateInputs(args: MarkerInput): ValidatedMarkerInput;
+export function loadGeojson(filePath: PathLike): FeatureCollectionLike;
+export function saveGeojson(filePath: PathLike, data: FeatureCollectionLike): true;
+export function extractExistingData(
+        geojsonData: FeatureCollectionLike | { features?: FeatureLike[] | undefined },
+): { existingIds: Set<string>; existingCoords: Set<string> };
+export function generateNextId(mapId: string, existingIds: Iterable<string>): string;
+export function checkDuplicates(
+        markerId: string,
+        x: number,
+        y: number,
+        existingIds: Set<string>,
+        existingCoords: Set<string>,
+): string[];
+export function createMarkerFeature(
+        markerId: string,
+        name: string,
+        category: CategoryId,
+        x: number,
+        y: number,
+        description?: string,
+): MarkerFeature;
+export function addMarkerToGeojson<T extends { features?: FeatureLike[] | undefined }>(
+        geojsonData: T,
+        markerFeature: FeatureLike,
+): T & { features: FeatureLike[] };
+export function displayMarkerPreview(markerFeature: MarkerFeature, filePath: string): void;
+export function main(argv?: string[], markersDir?: string): void;
+export function isExecutedDirectly(entry?: string | null, moduleUrl?: string): boolean;

--- a/scripts/add_marker.js
+++ b/scripts/add_marker.js
@@ -2,7 +2,90 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
-import { colors } from "../src/constants.js";
+import categoryColors from "../src/data/category-colors.json" assert { type: 'json' };
+
+const colors = /** @type {Record<string, string>} */ (categoryColors);
+
+/**
+ * @typedef {Object} FeatureGeometry
+ * @property {string} [type]
+ * @property {(number[] | [number, number])} [coordinates]
+ */
+
+/**
+ * @typedef {Object} FeatureLike
+ * @property {string} [type]
+ * @property {FeatureGeometry} [geometry]
+ * @property {Record<string, unknown>} [properties]
+ */
+
+/**
+ * @typedef {Object} FeatureCollectionLike
+ * @property {"FeatureCollection"} type
+ * @property {FeatureLike[]} features
+ */
+
+/**
+ * @typedef {Object} MarkerArgumentsBase
+ * @property {boolean} dryRun
+ */
+
+/**
+ * @typedef {MarkerArgumentsBase & {
+ *   categoriesFlag: false;
+ *   mapId: string;
+ *   x: number;
+ *   y: number;
+ *   category: string;
+ *   name: string;
+ *   description: string;
+ * }} MarkerArguments
+ */
+
+/**
+ * @typedef {MarkerArgumentsBase & {
+ *   categoriesFlag: true;
+ *   mapId: undefined;
+ *   x: undefined;
+ *   y: undefined;
+ *   category: undefined;
+ *   name: undefined;
+ *   description: "";
+ * }} CategoryListArguments
+ */
+
+/**
+ * @typedef {MarkerArguments | CategoryListArguments} ParsedArguments
+ */
+
+/**
+ * @typedef {Object} MarkerInput
+ * @property {boolean} [dryRun]
+ * @property {string} [mapId]
+ * @property {unknown} x
+ * @property {unknown} y
+ * @property {unknown} category
+ * @property {unknown} name
+ * @property {unknown} [description]
+ */
+
+/**
+ * @typedef {Object} ValidatedMarkerInput
+ * @property {boolean} [dryRun]
+ * @property {string} [mapId]
+ * @property {number} x
+ * @property {number} y
+ * @property {string} category
+ * @property {string} name
+ * @property {string} description
+ */
+
+/**
+ * @typedef {Object} MarkerFeature
+ * @property {"Feature"} type
+ * @property {{ type: "Point"; coordinates: [number, number] }} geometry
+ * @property {{ id: string; name: string; category: string; description?: string }} properties
+ */
 
 export const VALID_CATEGORIES = Object.freeze(Object.keys(colors));
 
@@ -10,8 +93,17 @@ export const DEFAULT_MARKERS_DIR = 'public/assets/data/markers';
 
 const COORD_SEPARATOR = ':';
 
+/**
+ * @param {number} x
+ * @param {number} y
+ * @returns {string}
+ */
 const toCoordKey = (x, y) => `${Number(x)}${COORD_SEPARATOR}${Number(y)}`;
 
+/**
+ * @param {string[]} [argv]
+ * @returns {ParsedArguments}
+ */
 export function parseArguments(argv = process.argv.slice(2)) {
   const options = { dryRun: false, categoriesFlag: false };
   const positional = [];
@@ -75,6 +167,10 @@ export function parseArguments(argv = process.argv.slice(2)) {
   };
 }
 
+/**
+ * @param {readonly string[]} [categories]
+ * @returns {void}
+ */
 export function showCategories(categories = VALID_CATEGORIES) {
   console.log('Valid marker categories:');
   for (const category of categories) {
@@ -82,6 +178,11 @@ export function showCategories(categories = VALID_CATEGORIES) {
   }
 }
 
+/**
+ * @param {string} mapId
+ * @param {string} [markersDir]
+ * @returns {string}
+ */
 export function getFilePath(mapId, markersDir = DEFAULT_MARKERS_DIR) {
   if (!mapId) {
     throw new Error('Map ID is required');
@@ -90,6 +191,10 @@ export function getFilePath(mapId, markersDir = DEFAULT_MARKERS_DIR) {
   return path.resolve(markersDir, `${mapId}.geojson`);
 }
 
+/**
+ * @param {MarkerInput} args
+ * @returns {ValidatedMarkerInput}
+ */
 export function validateInputs(args) {
   if (typeof args.x !== 'number' || typeof args.y !== 'number') {
     throw new Error('Coordinates must be numbers');
@@ -97,6 +202,10 @@ export function validateInputs(args) {
 
   if (args.x < 0 || args.y < 0) {
     throw new Error(`Coordinates must be non-negative. Got x=${args.x}, y=${args.y}`);
+  }
+
+  if (typeof args.category !== 'string') {
+    throw new Error(`Invalid category: ${String(args.category)}`);
   }
 
   if (!VALID_CATEGORIES.includes(args.category)) {
@@ -110,13 +219,23 @@ export function validateInputs(args) {
 
   const trimmedDescription = typeof args.description === 'string' ? args.description.trim() : '';
 
-  return {
-    ...args,
+  const mapId = typeof args.mapId === 'string' ? args.mapId : undefined;
+
+  return /** @type {ValidatedMarkerInput} */ ({
+    dryRun: Boolean(args.dryRun),
+    mapId,
+    x: args.x,
+    y: args.y,
+    category: args.category,
     name: trimmedName,
     description: trimmedDescription,
-  };
+  });
 }
 
+/**
+ * @param {import('node:fs').PathLike} filePath
+ * @returns {FeatureCollectionLike}
+ */
 export function loadGeojson(filePath) {
   if (fs.existsSync(filePath)) {
     try {
@@ -137,26 +256,41 @@ export function loadGeojson(filePath) {
         throw new Error(`Invalid JSON format: ${error.message}`);
       }
 
-      throw new Error(`Error reading file: ${error.message}`);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Error reading file: ${message}`);
     }
   }
 
-  return {
+  return /** @type {FeatureCollectionLike} */ ({
     type: 'FeatureCollection',
     features: [],
-  };
+  });
 }
 
+/**
+ * @param {import('node:fs').PathLike} filePath
+ * @param {FeatureCollectionLike} data
+ * @returns {true}
+ */
 export function saveGeojson(filePath, data) {
+  if (typeof filePath !== 'string') {
+    throw new TypeError('filePath must be a string path');
+  }
+
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   try {
     fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf-8');
     return true;
   } catch (error) {
-    throw new Error(`Error writing file: ${error.message}`);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Error writing file: ${message}`);
   }
 }
 
+/**
+ * @param {{ features?: FeatureLike[] }} geojsonData
+ * @returns {{ existingIds: Set<string>; existingCoords: Set<string> }}
+ */
 export function extractExistingData(geojsonData) {
   const existingIds = new Set();
   const existingCoords = new Set();
@@ -179,6 +313,11 @@ export function extractExistingData(geojsonData) {
   return { existingIds, existingCoords };
 }
 
+/**
+ * @param {string} mapId
+ * @param {Iterable<string>} existingIds
+ * @returns {string}
+ */
 export function generateNextId(mapId, existingIds) {
   const prefix = `${mapId}-`;
   let maxNumber = 0;
@@ -196,6 +335,14 @@ export function generateNextId(mapId, existingIds) {
   return `${prefix}${nextNumber.toString().padStart(3, '0')}`;
 }
 
+/**
+ * @param {string} markerId
+ * @param {number} x
+ * @param {number} y
+ * @param {Set<string>} existingIds
+ * @param {Set<string>} existingCoords
+ * @returns {string[]}
+ */
 export function checkDuplicates(markerId, x, y, existingIds, existingCoords) {
   const warnings = [];
 
@@ -210,7 +357,17 @@ export function checkDuplicates(markerId, x, y, existingIds, existingCoords) {
   return warnings;
 }
 
+/**
+ * @param {string} markerId
+ * @param {string} name
+ * @param {string} category
+ * @param {number} x
+ * @param {number} y
+ * @param {string} [description]
+ * @returns {MarkerFeature}
+ */
 export function createMarkerFeature(markerId, name, category, x, y, description = '') {
+  /** @type {MarkerFeature} */
   const feature = {
     type: 'Feature',
     geometry: {
@@ -231,6 +388,12 @@ export function createMarkerFeature(markerId, name, category, x, y, description 
   return feature;
 }
 
+/**
+ * @template T
+ * @param {T & { features?: FeatureLike[] }} geojsonData
+ * @param {FeatureLike} markerFeature
+ * @returns {T & { features: FeatureLike[] }}
+ */
 export function addMarkerToGeojson(geojsonData, markerFeature) {
   if (!Array.isArray(geojsonData.features)) {
     geojsonData.features = [];
@@ -238,14 +401,19 @@ export function addMarkerToGeojson(geojsonData, markerFeature) {
 
   geojsonData.features.push(markerFeature);
   geojsonData.features.sort((a, b) => {
-    const idA = a?.properties?.id ?? '';
-    const idB = b?.properties?.id ?? '';
+    const idA = typeof a?.properties?.id === 'string' ? a.properties.id : '';
+    const idB = typeof b?.properties?.id === 'string' ? b.properties.id : '';
     return idA.localeCompare(idB);
   });
 
-  return geojsonData;
+  return /** @type {T & { features: FeatureLike[] }} */ (geojsonData);
 }
 
+/**
+ * @param {MarkerFeature} markerFeature
+ * @param {string} filePath
+ * @returns {void}
+ */
 export function displayMarkerPreview(markerFeature, filePath) {
   const { properties, geometry } = markerFeature;
   console.log('\nMarker to be added:');
@@ -261,6 +429,11 @@ export function displayMarkerPreview(markerFeature, filePath) {
   console.log(JSON.stringify(markerFeature, null, 2));
 }
 
+/**
+ * @param {string[]} [argv]
+ * @param {string} [markersDir]
+ * @returns {void}
+ */
 export function main(argv = process.argv.slice(2), markersDir = DEFAULT_MARKERS_DIR) {
   const args = parseArguments(argv);
 
@@ -270,6 +443,10 @@ export function main(argv = process.argv.slice(2), markersDir = DEFAULT_MARKERS_
   }
 
   const validated = validateInputs(args);
+  if (!validated.mapId) {
+    throw new Error('Map ID is required');
+  }
+
   const filePath = getFilePath(validated.mapId, markersDir);
 
   console.log(`Target file: ${filePath}`);
@@ -330,6 +507,11 @@ export function main(argv = process.argv.slice(2), markersDir = DEFAULT_MARKERS_
   console.log(`✓ Total markers in file: ${updatedGeojson.features.length}`);
 }
 
+/**
+ * @param {string | null | undefined} [entry]
+ * @param {string} [moduleUrl]
+ * @returns {boolean}
+ */
 export function isExecutedDirectly(entry = process.argv[1], moduleUrl = import.meta.url) {
   if (!entry) {
     return false;
@@ -348,7 +530,8 @@ if (runFromCli) {
   try {
     main();
   } catch (error) {
-    console.error(`Error: ${error.message}`);
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error: ${message}`);
     process.exit(1);
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,11 @@
+import categoryColors from "./data/category-colors.json";
+import type { MarkerCategory } from "./types";
+
+export const colors = categoryColors satisfies Record<MarkerCategory, string>;
+
+export const categoryItemLabels: Partial<Record<MarkerCategory, string>> = {
+        duelist: "Rewards",
+        enemy: "Drops",
+        dungeon: "Loot",
+        shop: "Items",
+};

--- a/src/data/category-colors.json
+++ b/src/data/category-colors.json
@@ -1,0 +1,12 @@
+{
+        "music": "#00FFFF",
+        "card": "#39FF14",
+        "decal": "#FFD700",
+        "chest": "#FFFF00",
+        "enemy": "#FF1493",
+        "boss": "#FF0000",
+        "dungeon": "#800080",
+        "log": "#FF6E00",
+        "duelist": "#1E90FF",
+        "shop": "#1E90FF"
+}

--- a/tests/add_marker.test.ts
+++ b/tests/add_marker.test.ts
@@ -1,0 +1,557 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import * as nodeUrl from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+        addMarkerToGeojson,
+        checkDuplicates,
+        createMarkerFeature,
+        displayMarkerPreview,
+	extractExistingData,
+	generateNextId,
+	getFilePath,
+	isExecutedDirectly,
+	loadGeojson,
+	main,
+	parseArguments,
+	saveGeojson,
+	showCategories,
+        VALID_CATEGORIES,
+        validateInputs,
+} from "../scripts/add_marker.js";
+import type { FeatureCollectionLike, FeatureLike } from "../scripts/add_marker.js";
+
+const createTempDir = () =>
+	fs.mkdtempSync(path.join(os.tmpdir(), "add-marker-"));
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	process.exitCode = undefined;
+});
+
+describe("parseArguments", () => {
+	it("parses positional arguments with optional description", () => {
+		const args = parseArguments([
+			"forest",
+			"100",
+			"200",
+			"card",
+			"Marker",
+			"Detailed description",
+		]);
+		expect(args).toMatchObject({
+			mapId: "forest",
+			x: 100,
+			y: 200,
+			category: "card",
+			name: "Marker",
+			description: "Detailed description",
+			dryRun: false,
+			categoriesFlag: false,
+		});
+	});
+
+	it("supports --dry-run flag", () => {
+		const args = parseArguments([
+			"--dry-run",
+			"forest",
+			"10",
+			"20",
+			"card",
+			"Name",
+		]);
+		expect(args.dryRun).toBe(true);
+	});
+
+	it("returns early when --categories is provided", () => {
+		const args = parseArguments(["--categories", "--dry-run"]);
+		expect(args.categoriesFlag).toBe(true);
+		expect(args.dryRun).toBe(true);
+	});
+
+	it("throws when required arguments are missing", () => {
+		expect(() => parseArguments(["forest"])).toThrow(
+			"Missing required arguments",
+		);
+	});
+
+	it("throws when coordinates are not numbers", () => {
+		expect(() =>
+			parseArguments(["forest", "a", "100", "card", "Name"]),
+		).toThrow("Invalid x coordinate");
+		expect(() =>
+			parseArguments(["forest", "100", "b", "card", "Name"]),
+		).toThrow("Invalid y coordinate");
+	});
+});
+
+describe("showCategories", () => {
+	it("logs category list", () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		showCategories(["alpha", "beta"]);
+		expect(log).toHaveBeenCalledWith("Valid marker categories:");
+		expect(log).toHaveBeenCalledWith("  - alpha");
+		expect(log).toHaveBeenCalledWith("  - beta");
+	});
+});
+
+describe("getFilePath", () => {
+	it("resolves file path for map id", () => {
+                const resolved = getFilePath("forest", "relative/path");
+		expect(resolved).toContain(path.join("relative", "path", "forest.geojson"));
+	});
+
+	it("throws when map id is missing", () => {
+		expect(() => getFilePath("")).toThrow("Map ID is required");
+	});
+});
+
+describe("validateInputs", () => {
+	it("normalizes and validates input fields", () => {
+		const validated = validateInputs({
+			mapId: "forest",
+			x: 10,
+			y: 20,
+			category: VALID_CATEGORIES[0],
+			name: "  Marker  ",
+			description: "  Desc  ",
+			dryRun: false,
+		});
+		expect(validated.name).toBe("Marker");
+		expect(validated.description).toBe("Desc");
+	});
+
+	it("rejects non-number coordinates", () => {
+		expect(() =>
+			validateInputs({ x: "10", y: 10, category: "card", name: "Name" }),
+		).toThrow("Coordinates must be numbers");
+	});
+
+	it("rejects negative coordinates", () => {
+		expect(() =>
+			validateInputs({ x: -1, y: 0, category: "card", name: "Name" }),
+		).toThrow("Coordinates must be non-negative");
+	});
+
+        it("rejects invalid categories", () => {
+                expect(() =>
+                        validateInputs({ x: 0, y: 0, category: "invalid", name: "Name" }),
+                ).toThrow("Invalid category");
+        });
+
+        it("rejects non-string categories", () => {
+                expect(() =>
+                        validateInputs({ x: 0, y: 0, category: 42 as unknown, name: "Name" }),
+                ).toThrow("Invalid category");
+        });
+
+	it("rejects non-string names", () => {
+		expect(() =>
+			validateInputs({ x: 0, y: 0, category: "card", name: null }),
+		).toThrow("Marker name cannot be empty");
+	});
+
+	it("rejects empty names", () => {
+		expect(() =>
+			validateInputs({ x: 0, y: 0, category: "card", name: "   " }),
+		).toThrow("Marker name cannot be empty");
+	});
+
+	it("normalizes non-string descriptions to empty string", () => {
+		const validated = validateInputs({
+			x: 0,
+			y: 0,
+			category: "card",
+			name: "Name",
+			description: null,
+		});
+		expect(validated.description).toBe("");
+	});
+});
+
+describe("loadGeojson", () => {
+	it("returns empty structure when file does not exist", () => {
+		const tempPath = path.join(createTempDir(), "missing.geojson");
+		expect(loadGeojson(tempPath)).toEqual({
+			type: "FeatureCollection",
+			features: [],
+		});
+	});
+
+	it("loads existing valid file", () => {
+		const tempDir = createTempDir();
+		const filePath = path.join(tempDir, "file.geojson");
+		const data = { type: "FeatureCollection", features: [] };
+		fs.writeFileSync(filePath, JSON.stringify(data));
+		expect(loadGeojson(filePath)).toEqual(data);
+	});
+
+	it("throws on invalid JSON syntax", () => {
+		const tempDir = createTempDir();
+		const filePath = path.join(tempDir, "file.geojson");
+		fs.writeFileSync(filePath, "{");
+		expect(() => loadGeojson(filePath)).toThrow("Invalid JSON format");
+	});
+
+	it("throws when GeoJSON type is incorrect", () => {
+		const tempDir = createTempDir();
+		const filePath = path.join(tempDir, "file.geojson");
+		fs.writeFileSync(filePath, JSON.stringify({ type: "Other", features: [] }));
+		expect(() => loadGeojson(filePath)).toThrow(
+			"File is not a valid GeoJSON FeatureCollection",
+		);
+	});
+
+	it("throws when features is not an array", () => {
+		const tempDir = createTempDir();
+		const filePath = path.join(tempDir, "file.geojson");
+		fs.writeFileSync(
+			filePath,
+			JSON.stringify({ type: "FeatureCollection", features: {} }),
+		);
+		expect(() => loadGeojson(filePath)).toThrow(
+			"Invalid GeoJSON: 'features' must be an array",
+		);
+	});
+
+        it("wraps unexpected read errors", () => {
+                const _spy = vi.spyOn(fs, "existsSync").mockReturnValue(true);
+                vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+                        throw new Error("boom");
+                });
+                expect(() => loadGeojson("path")).toThrow("Error reading file: boom");
+        });
+
+        it("wraps non-error throws during read", () => {
+                const _spy = vi.spyOn(fs, "existsSync").mockReturnValue(true);
+                vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+                        throw "boom";
+                });
+                expect(() => loadGeojson("path")).toThrow("Error reading file: boom");
+        });
+});
+
+describe("saveGeojson", () => {
+	it("writes file with trailing newline", () => {
+		const tempDir = createTempDir();
+		const filePath = path.join(tempDir, "file.geojson");
+                const data: FeatureCollectionLike = {
+                        type: "FeatureCollection",
+                        features: [],
+                };
+                saveGeojson(filePath, data);
+                expect(fs.readFileSync(filePath, "utf-8")).toBe(
+                        `${JSON.stringify(data, null, 2)}\n`,
+                );
+        });
+
+        it("wraps write errors", () => {
+                const spy = vi.spyOn(fs, "writeFileSync").mockImplementation(() => {
+                        throw new Error("fail");
+                });
+                expect(() =>
+                        saveGeojson(
+                                "file",
+                                { type: "FeatureCollection", features: [] } as FeatureCollectionLike,
+                        ),
+                ).toThrow("Error writing file: fail");
+                spy.mockRestore();
+        });
+
+        it("wraps non-error throws during write", () => {
+                const spy = vi.spyOn(fs, "writeFileSync").mockImplementation(() => {
+                        throw "fail";
+                });
+                expect(() =>
+                        saveGeojson(
+                                "file",
+                                { type: "FeatureCollection", features: [] } as FeatureCollectionLike,
+                        ),
+                ).toThrow("Error writing file: fail");
+                spy.mockRestore();
+        });
+
+        it("throws when file path is not a string", () => {
+                expect(() => saveGeojson(42 as unknown as string, {
+                        type: "FeatureCollection",
+                        features: [],
+                } as FeatureCollectionLike)).toThrow("filePath must be a string path");
+        });
+});
+
+describe("extractExistingData", () => {
+	it("collects ids and coordinates", () => {
+		const data = {
+			type: "FeatureCollection",
+			features: [
+				{
+					properties: { id: "forest-001", name: "A" },
+					geometry: { coordinates: [100, 200] },
+				},
+				{
+					properties: { id: "forest-002", name: "B" },
+					geometry: { coordinates: [300, 400] },
+				},
+			],
+		};
+		const { existingIds, existingCoords } = extractExistingData(data);
+		expect(existingIds.has("forest-001")).toBe(true);
+		expect(existingCoords.has("100:200")).toBe(true);
+	});
+
+	it("handles missing fields gracefully", () => {
+		const { existingIds, existingCoords } = extractExistingData({
+			type: "FeatureCollection",
+			features: [{}],
+		});
+		expect(existingIds.size).toBe(0);
+		expect(existingCoords.size).toBe(0);
+	});
+
+	it("returns empty sets when features are absent", () => {
+		const { existingIds, existingCoords } = extractExistingData({});
+		expect(existingIds.size).toBe(0);
+		expect(existingCoords.size).toBe(0);
+	});
+});
+
+describe("generateNextId", () => {
+	it("generates sequential ids with padding", () => {
+		expect(generateNextId("forest", new Set())).toBe("forest-001");
+		expect(
+			generateNextId("forest", new Set(["forest-001", "forest-002"])),
+		).toBe("forest-003");
+	});
+
+	it("ignores ids from other maps and non-numeric suffixes", () => {
+		const existing = new Set(["desert-010", "forest-alpha", "forest-005"]);
+		expect(generateNextId("forest", existing)).toBe("forest-006");
+	});
+});
+
+describe("checkDuplicates", () => {
+	it("returns warnings for duplicates", () => {
+		const warnings = checkDuplicates(
+			"forest-001",
+			100,
+			200,
+			new Set(["forest-001"]),
+			new Set(["100:200"]),
+		);
+		expect(warnings).toEqual([
+			"ID 'forest-001' already exists",
+			"Coordinates (100, 200) already exist",
+		]);
+	});
+
+	it("returns empty array when there are no duplicates", () => {
+		expect(checkDuplicates("forest-002", 1, 2, new Set(), new Set())).toEqual(
+			[],
+		);
+	});
+});
+
+describe("createMarkerFeature", () => {
+	it("creates feature without description", () => {
+		const feature = createMarkerFeature("forest-001", "Name", "card", 1, 2);
+		expect(feature.properties).not.toHaveProperty("description");
+	});
+
+	it("adds description when provided", () => {
+		const feature = createMarkerFeature(
+			"forest-002",
+			"Name",
+			"card",
+			1,
+			2,
+			"Desc",
+		);
+		expect(feature.properties.description).toBe("Desc");
+	});
+});
+
+describe("addMarkerToGeojson", () => {
+	it("initializes missing feature array", () => {
+		const result = addMarkerToGeojson(
+			{},
+			createMarkerFeature("forest-002", "Name", "card", 1, 2),
+		);
+		expect(result.features).toHaveLength(1);
+	});
+
+	it("keeps markers sorted by id", () => {
+                const data: FeatureCollectionLike = {
+                        type: "FeatureCollection",
+                        features: [createMarkerFeature("forest-010", "A", "card", 1, 1)],
+                };
+                addMarkerToGeojson(
+                        data,
+                        createMarkerFeature("forest-002", "B", "card", 2, 2),
+                );
+                expect(data.features[0]!.properties?.id).toBe("forest-002");
+        });
+
+        it("handles items without ids during sorting", () => {
+                const data: { features: FeatureLike[] } = { features: [{}] };
+                addMarkerToGeojson(
+                        data,
+                        createMarkerFeature("forest-002", "Name", "card", 1, 1),
+                );
+                expect(data.features).toHaveLength(2);
+                expect(
+                        data.features.some(
+                                (feature) =>
+                                        (feature.properties as { id?: string } | undefined)?.id ===
+                                        "forest-002",
+                        ),
+                ).toBe(true);
+        });
+
+        it("supports markers without ids", () => {
+                const data: FeatureCollectionLike = {
+                        type: "FeatureCollection",
+                        features: [createMarkerFeature("forest-001", "Existing", "card", 0, 0)],
+                };
+                const anonymousFeature: FeatureLike = {
+                        type: "Feature",
+                        geometry: { type: "Point", coordinates: [1, 1] },
+                        properties: {},
+                };
+                addMarkerToGeojson(data, anonymousFeature);
+                expect(data.features).toHaveLength(2);
+                expect(
+                        data.features.some(
+                                (feature) =>
+                                        (feature.properties as { id?: string } | undefined)?.id === undefined,
+                        ),
+                ).toBe(true);
+        });
+});
+
+describe("displayMarkerPreview", () => {
+	it("logs marker preview including optional description", () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+                const feature = createMarkerFeature(
+                        "forest-001",
+                        "Name",
+                        "card",
+                        1,
+                        2,
+                        "Desc",
+                );
+                displayMarkerPreview(feature, "/tmp/file.geojson");
+                expect(log).toHaveBeenCalledWith("  Description: Desc");
+        });
+});
+
+describe("isExecutedDirectly", () => {
+        it("returns false when entry is missing", () => {
+                expect(isExecutedDirectly(null, "file:///module")).toBe(false);
+        });
+
+        it("returns false when path conversion throws", () => {
+                const invalidEntry = {} as unknown as string;
+                expect(isExecutedDirectly(invalidEntry, "file:///module")).toBe(false);
+        });
+
+        it("returns true when entry matches module url", () => {
+                const entry = path.join("tmp", "file.js");
+                const moduleUrl = nodeUrl.pathToFileURL(entry).href;
+                expect(isExecutedDirectly(entry, moduleUrl)).toBe(true);
+        });
+});
+
+describe("main", () => {
+	const captureLogs = () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		return { log, error };
+	};
+
+	it("shows categories and exits without error", () => {
+		const { log } = captureLogs();
+		main(["--categories"], createTempDir());
+		expect(log).toHaveBeenCalledWith("Valid marker categories:");
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("stops when duplicate coordinates are detected", () => {
+		const markersDir = createTempDir();
+		const filePath = getFilePath("forest", markersDir);
+		const existingFeature = createMarkerFeature(
+			"forest-001",
+			"Existing",
+			"card",
+			100,
+			200,
+		);
+		saveGeojson(filePath, {
+			type: "FeatureCollection",
+			features: [existingFeature],
+		});
+
+		const { error } = captureLogs();
+		main(["forest", "100", "200", "card", "New Name"], markersDir);
+		expect(error).toHaveBeenCalledWith("Error: Duplicate data detected:");
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("allows markers with duplicate names", () => {
+		const markersDir = createTempDir();
+		const filePath = getFilePath("forest", markersDir);
+		const existingFeature = createMarkerFeature(
+			"forest-001",
+			"Duplicate",
+			"card",
+			100,
+			200,
+		);
+		saveGeojson(filePath, {
+			type: "FeatureCollection",
+			features: [existingFeature],
+		});
+
+                const { log, error } = captureLogs();
+                main(["forest", "300", "400", "card", "Duplicate"], markersDir);
+                expect(error).not.toHaveBeenCalledWith("Error: Duplicate data detected:");
+                expect(process.exitCode).toBeUndefined();
+                expect(log).toHaveBeenCalledWith("✓ Total markers in file: 2");
+                const saved = JSON.parse(fs.readFileSync(filePath, "utf-8")) as FeatureCollectionLike;
+                expect(saved.features).toHaveLength(2);
+                const duplicates = saved.features.filter(
+                        (feature: FeatureLike) =>
+                                (feature.properties as { name?: string } | undefined)?.name === "Duplicate",
+                );
+                expect(duplicates).toHaveLength(2);
+	});
+
+	it("prints preview on dry run", () => {
+		const markersDir = createTempDir();
+		const { log } = captureLogs();
+		main(
+			["--dry-run", "forest", "10", "20", "card", "Name", " Description "],
+			markersDir,
+		);
+		expect(log).toHaveBeenCalledWith("\n[DRY RUN] No files will be modified");
+		expect(log).toHaveBeenCalledWith("  Description: Description");
+	});
+
+        it("adds marker to file when no duplicates", () => {
+                const markersDir = createTempDir();
+                const { log } = captureLogs();
+                main(["forest", "10", "20", "card", "Name"], markersDir);
+                const markerPath = getFilePath("forest", markersDir);
+                const saved = JSON.parse(fs.readFileSync(markerPath, "utf-8")) as FeatureCollectionLike;
+                expect(saved.features).toHaveLength(1);
+                expect(log).toHaveBeenCalledWith("✓ Total markers in file: 1");
+                expect(saved.features[0].properties).not.toHaveProperty("description");
+        });
+
+        it("throws when map id resolves to empty string", () => {
+                expect(() => main(["", "10", "20", "card", "Name"])).toThrow(
+                        "Map ID is required",
+                );
+        });
+});

--- a/tests/filter-pane.spec.ts
+++ b/tests/filter-pane.spec.ts
@@ -1,0 +1,290 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Page } from "@playwright/test";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, "..");
+const MARKERS_DIR = path.join(ROOT_DIR, "public", "assets", "data", "markers");
+
+interface MarkerSummary {
+        mapId: string;
+        id: string;
+        name: string;
+}
+
+const categoryToMarkers = new Map<string, MarkerSummary[]>();
+
+for (const file of fs.readdirSync(MARKERS_DIR)) {
+	if (!file.endsWith(".geojson")) {
+		continue;
+	}
+	const mapId = path.basename(file, ".geojson");
+	const content = fs.readFileSync(path.join(MARKERS_DIR, file), "utf8");
+	const data = JSON.parse(content);
+	for (const feature of data.features) {
+		const category = feature.properties.category;
+                if (!categoryToMarkers.has(category)) {
+                        categoryToMarkers.set(category, []);
+                }
+                categoryToMarkers.get(category)?.push({
+                        mapId,
+                        id: feature.properties.id,
+                        name: feature.properties.name || feature.properties.id,
+                });
+        }
+}
+
+const ALL_CATEGORIES = Array.from(categoryToMarkers.keys());
+const PRIMARY_CATEGORY = ALL_CATEGORIES.includes("music")
+        ? "music"
+        : ALL_CATEGORIES[0];
+const PRIMARY_DESERT_MARKER =
+        categoryToMarkers
+                .get(PRIMARY_CATEGORY)
+                ?.find((marker) => marker.mapId === "desert") ||
+        categoryToMarkers.get(PRIMARY_CATEGORY)?.[0];
+if (!PRIMARY_DESERT_MARKER) {
+        throw new Error("No markers available for primary category");
+}
+const PRIMARY_MARKER: MarkerSummary = PRIMARY_DESERT_MARKER;
+const SECONDARY_MAP_ID = PRIMARY_MARKER.mapId === "forest" ? "mountains" : "forest";
+const SECONDARY_MARKER = categoryToMarkers
+        .get(PRIMARY_CATEGORY)
+        ?.find((marker) => marker.mapId === SECONDARY_MAP_ID);
+const CARD_MARKER = categoryToMarkers
+        .get("card")
+        ?.find((marker) => marker.mapId === "desert");
+
+declare global {
+        interface Window {
+                __filterEvents?: Array<{ selectedCategories?: string[] }>;
+                __filterListener?: (event: CustomEvent<{ selectedCategories?: string[] }>) => void;
+        }
+}
+
+async function openFilterPane(page: Page): Promise<void> {
+        await page.getByTestId("filter-toggle").click();
+        await expect(page.getByTestId("filter-pane")).toBeVisible();
+        for (const category of ALL_CATEGORIES) {
+                await page.getByTestId(`filter-item-${category}`).waitFor();
+        }
+}
+
+async function openSearchPanel(page: Page) {
+        const toggle = page.getByRole("button", { name: "Toggle search panel" });
+        await toggle.click();
+        const input = page.getByPlaceholder("Search markers");
+        await expect(input).toBeVisible();
+        return input;
+}
+
+test.describe("filter pane", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/");
+	});
+
+	test("pane toggle shows all controls", async ({ page }) => {
+		await expect(page.getByTestId("filter-pane")).toBeHidden();
+		await openFilterPane(page);
+
+		await expect(page.getByTestId("filter-all")).toBeVisible();
+		await expect(page.getByTestId("filter-none")).toBeVisible();
+
+		for (const category of ALL_CATEGORIES) {
+			await expect(page.getByTestId(`filter-item-${category}`)).toBeVisible();
+		}
+	});
+
+	test("default state keeps all categories active", async ({ page }) => {
+		await openFilterPane(page);
+
+		for (const category of ALL_CATEGORIES) {
+			const checkbox = page
+				.getByTestId(`filter-item-${category}`)
+				.locator("input[type=checkbox]");
+			await expect(checkbox).toBeChecked();
+		}
+
+                await expect(
+                        page.locator(`[data-marker-id="${PRIMARY_MARKER.id}"]`),
+                ).toBeVisible();
+
+                const searchInput = await openSearchPanel(page);
+                await searchInput.fill(PRIMARY_MARKER.name.slice(0, 5));
+		await expect(page.getByTestId("search-result-item").first()).toBeVisible();
+	});
+
+	test("toggling a single category hides related markers and results", async ({
+		page,
+	}) => {
+		test.skip(
+                        !PRIMARY_MARKER,
+                        "No marker available for primary category",
+                );
+
+		await openFilterPane(page);
+		const targetRow = page.getByTestId(`filter-item-${PRIMARY_CATEGORY}`);
+		await targetRow.click();
+
+		await expect(targetRow.locator("input[type=checkbox]")).not.toBeChecked();
+                await expect(
+                        page.locator(`[data-marker-id="${PRIMARY_MARKER.id}"]`),
+                ).toHaveCount(0);
+
+		const searchInput = await openSearchPanel(page);
+                await searchInput.fill(PRIMARY_MARKER.name);
+		await expect(page.getByTestId("search-result-item")).toHaveCount(0);
+		await expect(page.locator("#search-message")).toContainText(
+			"No markers found",
+		);
+	});
+
+	test("all button re-enables every category", async ({ page }) => {
+		await openFilterPane(page);
+		const toggles = [
+			PRIMARY_CATEGORY,
+			CARD_MARKER?.id ? "card" : ALL_CATEGORIES[1],
+		];
+
+		for (const category of toggles) {
+			if (!category) continue;
+			await page.getByTestId(`filter-item-${category}`).click();
+		}
+
+		await page.getByTestId("filter-all").click();
+
+		for (const category of ALL_CATEGORIES) {
+			await expect(
+				page
+					.getByTestId(`filter-item-${category}`)
+					.locator("input[type=checkbox]"),
+			).toBeChecked();
+		}
+
+                await expect(
+                        page.locator(`[data-marker-id="${PRIMARY_MARKER.id}"]`),
+                ).toBeVisible();
+	});
+
+	test("none button clears all markers and results", async ({ page }) => {
+		await openFilterPane(page);
+		await page.getByTestId("filter-none").click();
+
+		for (const category of ALL_CATEGORIES) {
+			await expect(
+				page
+					.getByTestId(`filter-item-${category}`)
+					.locator("input[type=checkbox]"),
+			).not.toBeChecked();
+		}
+
+		await expect(page.getByTestId("map-marker")).toHaveCount(0);
+
+		const searchInput = await openSearchPanel(page);
+                await searchInput.fill(PRIMARY_MARKER.name);
+                await expect(page.getByTestId("search-result-item")).toHaveCount(0);
+                await expect(page.locator("#search-message")).toContainText(
+                        "No markers found",
+                );
+	});
+
+	test("preferences persist after reload", async ({ page }) => {
+		await openFilterPane(page);
+		await page.getByTestId(`filter-item-${PRIMARY_CATEGORY}`).click();
+                await expect(
+                        page.locator(`[data-marker-id="${PRIMARY_MARKER.id}"]`),
+                ).toHaveCount(0);
+
+		await page.reload();
+		await openFilterPane(page);
+
+                await expect(
+                        page
+                                .getByTestId(`filter-item-${PRIMARY_CATEGORY}`)
+                                .locator("input[type=checkbox]"),
+                ).not.toBeChecked();
+                await expect(
+                        page.locator(`[data-marker-id="${PRIMARY_MARKER.id}"]`),
+                ).toHaveCount(0);
+	});
+
+        test("filter selection is shared across maps", async ({ page }) => {
+                test.skip(
+                        !SECONDARY_MARKER,
+                        "No secondary marker available for selected category",
+                );
+                const secondaryMarker = SECONDARY_MARKER as MarkerSummary;
+                await openFilterPane(page);
+                await page.getByTestId(`filter-item-${PRIMARY_CATEGORY}`).click();
+
+                await page.locator(`.map-link[data-map="${SECONDARY_MAP_ID}"]`).click();
+
+                await expect(
+                        page.locator(`[data-marker-id="${secondaryMarker.id}"]`),
+                ).toHaveCount(0);
+		await expect(
+			page
+				.getByTestId(`filter-item-${PRIMARY_CATEGORY}`)
+				.locator("input[type=checkbox]"),
+		).not.toBeChecked();
+	});
+
+	test("keyboard navigation toggles items", async ({ page }) => {
+		await openFilterPane(page);
+		const firstCategory = ALL_CATEGORIES[0];
+		const secondCategory = ALL_CATEGORIES[1] || ALL_CATEGORIES[0];
+		const firstRow = page.getByTestId(`filter-item-${firstCategory}`);
+		await firstRow.focus();
+		await page.keyboard.press("Space");
+		await expect(firstRow.locator("input[type=checkbox]")).not.toBeChecked();
+
+		await page.keyboard.press("ArrowDown");
+		const secondRow = page.getByTestId(`filter-item-${secondCategory}`);
+		await secondRow.focus();
+		await page.keyboard.press("Enter");
+		await expect(secondRow.locator("input[type=checkbox]")).not.toBeChecked();
+	});
+
+	test("filter changed event emits payload", async ({ page }) => {
+                await page.evaluate(() => {
+                        window.__filterEvents = [];
+                        const listener = (
+                                event: CustomEvent<{ selectedCategories?: string[] }>,
+                        ) => {
+                                (window.__filterEvents ??= []).push(event.detail);
+                        };
+                        window.__filterListener = listener;
+                        document.addEventListener(
+                                "filter:changed",
+                                listener as EventListener,
+                        );
+                });
+
+		await openFilterPane(page);
+                await page.getByTestId(`filter-item-${PRIMARY_CATEGORY}`).click();
+                await page.getByTestId("filter-all").click();
+
+                const events = await page.evaluate(() => window.__filterEvents ?? []);
+                expect(events.length).toBeGreaterThanOrEqual(2);
+                expect(events[events.length - 1]?.selectedCategories).toBeDefined();
+                expect(Array.isArray(events[events.length - 1].selectedCategories)).toBe(
+                        true,
+                );
+        });
+
+        test("search results exclude filtered categories", async ({ page }) => {
+                await openFilterPane(page);
+                await page.getByTestId(`filter-item-${PRIMARY_CATEGORY}`).click();
+
+                const searchInput = await openSearchPanel(page);
+                await searchInput.fill(PRIMARY_MARKER.name);
+                await expect(page.getByTestId("search-result-item")).toHaveCount(0);
+
+                await page.getByTestId("filter-all").click();
+                await searchInput.fill("");
+                await searchInput.fill(PRIMARY_MARKER.name);
+                await expect(page.getByTestId("search-result-item").first()).toBeVisible();
+        });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		environment: "node",
-		include: ["tests/**/*.test.js"],
+                include: ["tests/**/*.test.ts"],
 		pool: "threads",
 		poolOptions: {
 			threads: {


### PR DESCRIPTION
## Summary
- align the add_marker CLI with stricter typings by sourcing categories from JSON, documenting helpers, and tightening runtime guards
- update the script declaration file and batch_add_markers utility to expose accurate types for Vitest
- expand unit and Playwright tests plus Vitest configuration so the new TypeScript sources are covered

## Testing
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d5f1a266f0832cabff662c52082256