### PR TITLE
docs: add TypeScript migration wrap-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Detailed credits and support information are available on the [About page](./abo
 - Mobile-friendly responsive design
 
 ## Technical Stack
-- **Frontend**: Vanilla HTML/CSS/JavaScript (ES modules)
+- **Frontend**: Vanilla HTML/CSS/TypeScript (ES modules)
 - **Build Tool**: Vite
 - **Map Library**: [Leaflet.js](https://leafletjs.com/) v1.9.4 (npm package)
 - **Data Storage**: Browser localStorage
@@ -70,8 +70,15 @@ pnpm build
 
 ### Code Quality
 ```bash
-# Run linting and formatting checks
+# Static analysis and formatting
 pnpm check
+
+# TypeScript type-checking
+pnpm typecheck
+
+# Run the automated test suites
+pnpm test
+pnpm exec playwright test
 
 # Auto-fix issues
 pnpm fix
@@ -139,13 +146,15 @@ This is primarily a personal project for game progress tracking.
 While contributions are welcome, please note the scope is intentionally limited to maintain simplicity.
 
 ### Development Guidelines
-- Use vanilla JavaScript (ES6+ modules)
-- Console logging for debugging is standard practice
-- Follow existing code style and patterns
-- Use Biome for code formatting and linting
-- Test changes across different browsers
-- Ensure mobile compatibility
-- Run `pnpm check` before committing changes
+- Use TypeScript modules with ES2022 syntax.
+- Prefer explicit types for public exports; allow inference for narrow-scope locals when it keeps intent clear.
+- Console logging for debugging is standard practice.
+- Follow existing code style and patterns.
+- Use Biome for code formatting and linting.
+- Keep shared type definitions in `src/types/` so modules can import stable contracts.
+- Run `pnpm check`, `pnpm typecheck`, `pnpm test`, and `pnpm exec playwright test` before committing changes.
+- Test changes across different browsers and ensure mobile compatibility.
+- Refer to [`docs/typescript-migration/wrap-up.md`](./docs/typescript-migration/wrap-up.md) for post-migration conventions and lessons learned.
 
 #### CSS Important Rules
 This project uses `!important` declarations in CSS for the following justified reasons:
@@ -164,4 +173,4 @@ The detailed module-by-module conversion order lives in [`docs/typescript-migrat
 
 ---
 
-*This project is maintained as a fan project and learning exercise. It uses a modern Vite-based development workflow while maintaining vanilla JavaScript for the core application logic.*
+*This project is maintained as a fan project and learning exercise. It uses a modern Vite-based development workflow while keeping the core application logic in TypeScript modules that compile to vanilla JavaScript for the browser.*

--- a/docs/typescript-migration/baseline.md
+++ b/docs/typescript-migration/baseline.md
@@ -61,4 +61,4 @@ Capture full-screen PNGs in `docs/typescript-migration/screenshots/` before the 
   4. **Controller + entry point** – Convert `app-controller.js` and `main.js`, ensuring build output stays tree-shakeable.
   5. **Final clean-up** – Remove unused `.js` stubs, enable `noImplicitAny`, and rerun the baseline quality gates.
 
-Document the results of each checkpoint (tests, lint, build, screenshots) in follow-up entries under this directory to keep the migration auditable.
+Document the results of each checkpoint (tests, lint, build, screenshots) in follow-up entries under this directory to keep the migration auditable. The final clean-up summary and long-term conventions live in [`wrap-up.md`](./wrap-up.md).

--- a/docs/typescript-migration/wrap-up.md
+++ b/docs/typescript-migration/wrap-up.md
@@ -1,0 +1,41 @@
+# TypeScript Migration Wrap-up
+
+This document captures the final housekeeping that followed the TypeScript conversion. It records the state of the quality gates, summarises clean-up tasks, and documents conventions that should guide future TypeScript development.
+
+## Final Quality Gates
+
+| Command | Status | Notes |
+| --- | --- | --- |
+| `pnpm check` | ✅ Passed | Biome reports no formatting or linting issues.
+| `pnpm typecheck` | ✅ Passed | `tsc --noEmit` completes with zero errors across the codebase.
+| `pnpm test` | ✅ Passed | Vitest suite runs with coverage enabled and no regressions.
+| `pnpm exec playwright test` | ✅ Passed | UI smoke tests succeed using the Playwright configuration in the repository.
+| `pnpm build` | ✅ Passed | Vite outputs production assets under `dist/` without warnings.
+
+*(See the latest CI or local command logs for timestamps associated with these runs.)*
+
+## Clean-up Checklist
+
+- Confirmed that the codebase no longer requires `// @ts-ignore` or redundant JSDoc shims now that modules expose typed exports directly.
+- Audited module exports to ensure they surface concrete types (for example, the `MarkerCategory` union in `src/types/index.d.ts`).
+- Updated repository documentation so the README, contribution guidance, and migration tracker all reflect TypeScript-first development.
+
+## TypeScript Conventions
+
+The migration surfaced a handful of practices that keep the project maintainable:
+
+1. **Type-first module boundaries** – every public export should have an explicit type signature. Prefer re-exporting shared types from `src/types/` when multiple modules need the same contract.
+2. **Leaflet integration** – extend Leaflet via ambient declarations in `src/types/leaflet-extensions.d.ts` rather than `@ts-ignore` patches in implementation files.
+3. **DOM access** – narrow DOM queries with user-defined type guards where necessary instead of asserting with `as HTMLElement`. Typed helper functions (for example, in `filter-pane.ts`) should return refined element types.
+4. **Storage safety** – keep persistence logic (`collection-store.ts`, `preferences-store.ts`) strongly typed by modelling JSON payloads with discriminated unions and helper guards.
+5. **URL parameters** – coordinate URL parsing and serialisation through `url-state.ts`, ensuring functions accept the `MapId` and `MarkerId` unions exported from `src/types/`.
+6. **Testing strategy** – mirror production types in tests so refactors catch API changes. Prefer importing the same TypeScript definitions rather than duplicating structural types inside the test suite.
+
+## Lessons Learned
+
+- Investing in shared literal unions up-front (`MarkerCategory`, `MapId`) removed the need for runtime assertions later in the migration.
+- Type annotations around Leaflet integrations pay off quickly—hover interactions and marker toggles became easier to reason about once the callback signatures were explicit.
+- Running `pnpm typecheck` alongside `pnpm check`, `pnpm test`, and `pnpm exec playwright test` before each commit provided fast feedback and prevented regressions from slipping in between migration waves.
+- Maintaining human-readable documentation during the migration made it easier to onboard helpers without repeating historical context in pull requests.
+
+Future enhancements should continue to update this document so the agreed TypeScript practices stay current.


### PR DESCRIPTION
## Summary
- document the post-migration cleanup and conventions in docs/typescript-migration/wrap-up.md and link it from the baseline plan
- refresh the README to reflect the TypeScript stack and expand the contributor workflow expectations

## Testing
- pnpm typecheck
- pnpm check
- pnpm test
- pnpm exec playwright test
- pnpm build

Closes #60 

------
https://chatgpt.com/codex/tasks/task_e_68d63fd51348832c8c96e7c58021b2ec